### PR TITLE
Google Group and LinkedIn Group

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,8 @@
               <li class="active"><a href="#">Home</a></li>
               <li><a href="https://github.com/celluloid">Projects</a></li>
               <li><a href="https://github.com/celluloid/celluloid/wiki">Wiki</a></li>
+              <li><a href="https://groups.google.com/forum/#!forum/celluloid-ruby">Google Group</a></li>
+              <li><a href="https://www.linkedin.com/grp/home?gid=6996017">LinkedIn Group</a></li>
               <li><a href="https://github.com/tarcieri">Author</a></li>
             </ul>
           </div><!--/.nav-collapse -->


### PR DESCRIPTION
Adding links to the Google and LinkedIn groups to the topnav.

An overall revamp ought to happen at some point ( especially once there's a blog ). For now this can buy some time. It's possible this should be scratched in favor of adding a "contact" or "connect" page, including:

* Google Group
* LinkedIn Group
* IRC Channel
* Twitter handles
  * `@celluloidrb`
  * `@reelrb`
  * Author
  * Maintainer

/cc: @tarcieri 